### PR TITLE
support repositories that have orphan branches.

### DIFF
--- a/src/main/java/jp/kusumotolab/finergit/BranchName.java
+++ b/src/main/java/jp/kusumotolab/finergit/BranchName.java
@@ -15,6 +15,10 @@ public class BranchName {
     }
   }
 
+  static public boolean isMasterBranch(final int id) {
+    return id == 0;
+  }
+
   private final AtomicInteger id;
 
   public BranchName() {

--- a/src/main/java/jp/kusumotolab/finergit/FinerRepo.java
+++ b/src/main/java/jp/kusumotolab/finergit/FinerRepo.java
@@ -64,25 +64,26 @@ public class FinerRepo {
     }
 
     return true;
-
   }
 
   public boolean doCheckoutCommand(final String branchName, final boolean create,
-      final RevCommit startPoint) {
-    log.trace("enter doCheckoutCommand(String=\"{}\", boolean=\"{}\", RevCommit=\"{}\")",
-        branchName, create, RevCommitUtil.getAbbreviatedID(startPoint));
+      final RevCommit startPoint, final boolean orphan) {
+    log.trace(
+        "enter doCheckoutCommand(String=\"{}\", boolean=\"{}\", RevCommit=\"{}\", boolean=\"{}\")",
+        branchName, create, RevCommitUtil.getAbbreviatedID(startPoint), orphan);
 
     final CheckoutCommand checkoutCommand = this.git.checkout();
     checkoutCommand.setCreateBranch(create)
         .setName(branchName)
-        .setStartPoint(startPoint);
+        .setStartPoint(startPoint)
+        .setOrphan(orphan);
     try {
       checkoutCommand.call();
       return true;
     } catch (final Exception e) {
       log.error(
-          "git-checkout command failed, branchName <{}>, create <{}>, startPoint <{}>, Exception.getMessage <{}>",
-          branchName, create, RevCommitUtil.getAbbreviatedID(startPoint), e.getMessage());
+          "git-checkout command failed, branchName <{}>, create <{}>, startPoint <{}>, orphan <{}>, Exception.getMessage <{}>",
+          branchName, create, RevCommitUtil.getAbbreviatedID(startPoint), orphan, e.getMessage());
       log.error(e.getMessage());
       return false;
     }


### PR DESCRIPTION
orphanブランチをもつリポジトリへの対応．
checkoutcommand#setOrphan(true)して対応したいが，なぜが親のあるbranchになってしまう．
それでも解析上は問題ないので，とりあえずいったんおしまい．