### PR TITLE
Copy-and-rewrite source repository when creating FinerGit repository

### DIFF
--- a/src/main/java/finergit/FinerGitMain.java
+++ b/src/main/java/finergit/FinerGitMain.java
@@ -5,6 +5,7 @@ import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import ch.qos.logback.classic.Level;
 import finergit.util.Timer;
 
@@ -14,7 +15,7 @@ public class FinerGitMain {
 
   /**
    * Gitリポジトリから細粒度リポジトリを作成するためのメインメソッド
-   * 
+   *
    * @param args
    */
   public static void main(final String[] args) {
@@ -36,18 +37,10 @@ public class FinerGitMain {
     timer.start();
 
     final FinerGitMain finerGitMain = new FinerGitMain(config);
-    final FinerRepo finerRepo = finerGitMain.exec();
-
+    finerGitMain.exec();
 
     timer.stop();
     log.info("elapsed time: {}", timer.toString());
-    log.info("  git-add:      {}", finerRepo.getAddCommandExecutionTime());
-    log.info("  git-checkout: {}", finerRepo.getCheckoutCommandExcecutionTime());
-    log.info("  git-commit:   {}", finerRepo.getCommitCommandExecutionTime());
-    log.info("  git-merge:    {}", finerRepo.getMergeCommandExecutionTime());
-    log.info("  git-rm:       {}", finerRepo.getRmCommandExecutionTime());
-    log.info("  git-status:   {}", finerRepo.getStatusCommandExcutionTime());
-    log.info("  git-listfile: {}", finerRepo.getListFilesExcutionTime());
   }
 
   private final FinerGitConfig config;
@@ -64,11 +57,11 @@ public class FinerGitMain {
     windowCacheConfig.install();
   }
 
-  public FinerRepo exec() {
+  public void exec() {
     log.trace("enter exec()");
     // final FinerRepoBuilder builder = new FinerRepoBuilder(this.config);
     // return builder.exec();
     final TreeRewriteFinerRepoBuilder builder = new TreeRewriteFinerRepoBuilder(this.config);
-    return builder.exec();
+    builder.exec();
   }
 }

--- a/src/main/java/finergit/FinerGitRewriter.java
+++ b/src/main/java/finergit/FinerGitRewriter.java
@@ -10,12 +10,12 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import finergit.ast.FinerJavaFileBuilder;
 import finergit.ast.FinerJavaModule;
-import finergit.rewrite.ConcurrentRepositoryRewriter;
-import finergit.rewrite.EntrySet;
-import finergit.rewrite.EntrySet.Entry;
-import finergit.rewrite.EntrySet.EntryList;
-import finergit.rewrite.RefEntry;
 import finergit.util.RevCommitUtil;
+import jp.ac.titech.c.se.stein.core.ConcurrentRepositoryRewriter;
+import jp.ac.titech.c.se.stein.core.EntrySet;
+import jp.ac.titech.c.se.stein.core.RefEntry;
+import jp.ac.titech.c.se.stein.core.EntrySet.Entry;
+import jp.ac.titech.c.se.stein.core.EntrySet.EntryList;
 
 public class FinerGitRewriter extends ConcurrentRepositoryRewriter {
 

--- a/src/main/java/finergit/FinerGitRewriter.java
+++ b/src/main/java/finergit/FinerGitRewriter.java
@@ -40,11 +40,7 @@ public class FinerGitRewriter extends ConcurrentRepositoryRewriter {
 
     // Treats non-java files
     if (!entry.name.endsWith(".java")) {
-      if (config.isOtherFilesIncluded()) {
-        return super.rewriteEntry(entry);
-      } else {
-        return Entry.EMPTY;
-      }
+      return config.isOtherFilesIncluded() ? super.rewriteEntry(entry) : Entry.EMPTY;
     }
 
     // Convert to finer modules

--- a/src/main/java/finergit/FinerGitRewriter.java
+++ b/src/main/java/finergit/FinerGitRewriter.java
@@ -4,18 +4,20 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+
 import finergit.ast.FinerJavaFileBuilder;
 import finergit.ast.FinerJavaModule;
 import finergit.util.RevCommitUtil;
 import jp.ac.titech.c.se.stein.core.ConcurrentRepositoryRewriter;
 import jp.ac.titech.c.se.stein.core.EntrySet;
-import jp.ac.titech.c.se.stein.core.RefEntry;
 import jp.ac.titech.c.se.stein.core.EntrySet.Entry;
 import jp.ac.titech.c.se.stein.core.EntrySet.EntryList;
+import jp.ac.titech.c.se.stein.core.RefEntry;
 
 public class FinerGitRewriter extends ConcurrentRepositoryRewriter {
 
@@ -25,14 +27,13 @@ public class FinerGitRewriter extends ConcurrentRepositoryRewriter {
 
   private final ObjectId head;
 
-  public FinerGitRewriter(final FinerGitConfig config, final Repository src, final Repository dst,
-      final ObjectId head) {
+  public FinerGitRewriter(final FinerGitConfig config, final Repository repo, final ObjectId head) {
     this.config = config;
     this.builder = new FinerJavaFileBuilder(config);
     this.head = head;
     setConcurrent(true);
     setPathSensitive(true);
-    initialize(src, dst);
+    initialize(repo);
   }
 
   @Override
@@ -62,7 +63,7 @@ public class FinerGitRewriter extends ConcurrentRepositoryRewriter {
     // Treats non-java files
     if (!entry.name.endsWith(".java")) {
       if (config.isOtherFilesIncluded()) {
-        return new Entry(entry.mode, entry.name, writeBlob(readBlob(entry.id)), entry.pathContext);
+        return super.rewriteEntry(entry);
       } else {
         return Entry.EMPTY;
       }

--- a/src/main/java/finergit/FinerGitRewriter.java
+++ b/src/main/java/finergit/FinerGitRewriter.java
@@ -1,13 +1,9 @@
 package finergit;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 
 import finergit.ast.FinerJavaFileBuilder;
@@ -17,7 +13,6 @@ import jp.ac.titech.c.se.stein.core.ConcurrentRepositoryRewriter;
 import jp.ac.titech.c.se.stein.core.EntrySet;
 import jp.ac.titech.c.se.stein.core.EntrySet.Entry;
 import jp.ac.titech.c.se.stein.core.EntrySet.EntryList;
-import jp.ac.titech.c.se.stein.core.RefEntry;
 
 public class FinerGitRewriter extends ConcurrentRepositoryRewriter {
 
@@ -25,28 +20,11 @@ public class FinerGitRewriter extends ConcurrentRepositoryRewriter {
 
   private final FinerJavaFileBuilder builder;
 
-  private final ObjectId head;
-
-  public FinerGitRewriter(final FinerGitConfig config, final Repository repo, final ObjectId head) {
+  public FinerGitRewriter(final FinerGitConfig config) {
     this.config = config;
     this.builder = new FinerJavaFileBuilder(config);
-    this.head = head;
     setConcurrent(true);
     setPathSensitive(true);
-    initialize(repo);
-  }
-
-  @Override
-  protected Collection<ObjectId> collectStarts() {
-    return Collections.singletonList(head);
-  }
-
-  public static final String MASTER = Constants.R_HEADS + "master";
-
-  @Override
-  protected void updateRefs() {
-    applyRefUpdate(new RefEntry(MASTER, rewriteReferredCommit(head, null)));
-    applyRefUpdate(new RefEntry(Constants.HEAD, MASTER));
   }
 
   @Override

--- a/src/main/java/finergit/TreeRewriteFinerGitMain.java
+++ b/src/main/java/finergit/TreeRewriteFinerGitMain.java
@@ -56,9 +56,9 @@ public class TreeRewriteFinerGitMain {
     windowCacheConfig.install();
   }
 
-  public FinerRepo exec() {
+  public void exec() {
     log.trace("enter exec()");
     final TreeRewriteFinerRepoBuilder builder = new TreeRewriteFinerRepoBuilder(this.config);
-    return builder.exec();
+    builder.exec();
   }
 }

--- a/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
+++ b/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import org.eclipse.jgit.revwalk.RevCommit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,15 +36,8 @@ public class TreeRewriteFinerRepoBuilder {
       repo = new GitRepo(this.config.getDesPath());
       repo.initialize();
 
-      // retrieve HEAD information
-      final String headCommitId = this.config.getHeadCommitId();
-      final RevCommit headCommit = null != headCommitId ? repo.getCommit(headCommitId) : repo.getHeadCommit();
-      if (null == headCommit) {
-        log.error("\"{}\" is an invalid commit ID for option \"--head\"", headCommitId);
-        System.exit(0);
-      }
-
-      final FinerGitRewriter rewriter = new FinerGitRewriter(config, repo.getRepository(), headCommit);
+      final FinerGitRewriter rewriter = new FinerGitRewriter(config);
+      rewriter.initialize(repo.getRepository());
       rewriter.rewrite();
 
     } catch (final Exception e) {

--- a/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
+++ b/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
@@ -52,7 +52,7 @@ public class TreeRewriteFinerRepoBuilder {
    * Copy a directory recursively.
    */
   protected void copyDirectory(final Path source, final Path target) throws IOException {
-    log.debug("Duplicate repository: {} to {}", source, target);
+    log.debug("Copy directory: {} to {}", source, target);
     Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
       @Override
       public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException {

--- a/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
+++ b/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
@@ -1,5 +1,12 @@
 package finergit;
 
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,32 +22,30 @@ public class TreeRewriteFinerRepoBuilder {
   private static final Logger log = LoggerFactory.getLogger(TreeRewriteFinerRepoBuilder.class);
 
   private final FinerGitConfig config;
-  private final GitRepo srcRepo;
-  private final FinerRepo desRepo;
 
   public TreeRewriteFinerRepoBuilder(final FinerGitConfig config) {
     log.trace("enter FinerRepoBuilder(FinerGitConfig)");
     this.config = config;
-    this.srcRepo = new GitRepo(this.config.getSrcPath());
-    this.desRepo = new FinerRepo(this.config.getDesPath());
   }
 
-  public FinerRepo exec() {
+  public GitRepo exec() {
     log.trace("enter exec()");
+    GitRepo repo = null;
     try {
-      // initialize finer repository
-      this.srcRepo.initialize();
-      this.desRepo.initialize();
+      // duplicate repository
+      copyDirectory(this.config.getSrcPath(), this.config.getDesPath());
+      repo = new GitRepo(this.config.getDesPath());
+      repo.initialize();
 
       // retrieve HEAD information
       final String headCommitId = this.config.getHeadCommitId();
-      final RevCommit headCommit = null != headCommitId ? this.srcRepo.getCommit(headCommitId) : this.srcRepo.getHeadCommit();
+      final RevCommit headCommit = null != headCommitId ? repo.getCommit(headCommitId) : repo.getHeadCommit();
       if (null == headCommit) {
         log.error("\"{}\" is an invalid commit ID for option \"--head\"", headCommitId);
         System.exit(0);
       }
 
-      final FinerGitRewriter rewriter = new FinerGitRewriter(config, srcRepo.getRepository(), desRepo.getRepository(), headCommit);
+      final FinerGitRewriter rewriter = new FinerGitRewriter(config, repo.getRepository(), headCommit);
       rewriter.rewrite();
 
     } catch (final Exception e) {
@@ -48,6 +53,26 @@ public class TreeRewriteFinerRepoBuilder {
     }
 
     log.trace("exit exec()");
-    return this.desRepo;
+    return repo;
+  }
+
+  /**
+   * Copy a directory recursively.
+   */
+  protected void copyDirectory(final Path source, final Path target) throws IOException {
+    log.debug("Duplicate repository: {} to {}", source, target);
+    Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException {
+        Files.createDirectories(target.resolve(source.relativize(dir)));
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+        Files.copy(file, target.resolve(source.relativize(file)));
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 }

--- a/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
+++ b/src/main/java/finergit/TreeRewriteFinerRepoBuilder.java
@@ -40,6 +40,12 @@ public class TreeRewriteFinerRepoBuilder {
       rewriter.initialize(repo.getRepository());
       rewriter.rewrite();
 
+      // clean up working copy
+      final boolean resetSucceeded = repo.resetHard();
+      log.debug("git reset --hard: {}", resetSucceeded ? "succeeded" : "failed");
+      final boolean cleanSucceeded = repo.clean();
+      log.debug("git clean -fd: {}", cleanSucceeded ? "succeeded" : "failed");
+
     } catch (final Exception e) {
       e.printStackTrace();
     }

--- a/src/main/java/jp/ac/titech/c/se/stein/core/ConcurrentRepositoryRewriter.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/ConcurrentRepositoryRewriter.java
@@ -1,4 +1,4 @@
-package finergit.rewrite;
+package jp.ac.titech.c.se.stein.core;
 
 import java.util.HashMap;
 import java.util.Spliterator;
@@ -14,7 +14,7 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import finergit.rewrite.Try.ThrowableFunction;
+import jp.ac.titech.c.se.stein.core.Try.ThrowableFunction;
 
 public class ConcurrentRepositoryRewriter extends RepositoryRewriter {
     private static final Logger log = LoggerFactory.getLogger(ConcurrentRepositoryRewriter.class);

--- a/src/main/java/jp/ac/titech/c/se/stein/core/ConcurrentRepositoryRewriter.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/ConcurrentRepositoryRewriter.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import jp.ac.titech.c.se.stein.core.Try.ThrowableFunction;
 
-public class ConcurrentRepositoryRewriter extends RepositoryRewriter {
+public class ConcurrentRepositoryRewriter extends RepositoryRewriter implements Configurable {
     private static final Logger log = LoggerFactory.getLogger(ConcurrentRepositoryRewriter.class);
 
     protected boolean concurrent = false;
@@ -27,6 +27,21 @@ public class ConcurrentRepositoryRewriter extends RepositoryRewriter {
         log.debug("Set concurrent: {}", concurrent);
         this.concurrent = concurrent;
         this.entryMapping = concurrent ? new ConcurrentHashMap<>() : new HashMap<>();
+        log.debug("Concurrent mode: {}", concurrent);
+    }
+
+    @Override
+    public void addOptions(final Config conf) {
+        super.addOptions(conf);
+        conf.addOption("c", "concurrent", false, "rewrite trees concurrently");
+    }
+
+    @Override
+    public void configure(final Config conf) {
+        super.configure(conf);
+        if (conf.hasOption("concurrent")) {
+            setConcurrent(true);
+        }
     }
 
     /**

--- a/src/main/java/jp/ac/titech/c/se/stein/core/Config.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/Config.java
@@ -1,0 +1,9 @@
+package jp.ac.titech.c.se.stein.core;
+
+public interface Config {
+    void addOption(final String opt, final String longOpt, final boolean hasArg, final String description);
+
+    boolean hasOption(final String opt);
+
+    String getOptionValue(final String opt);
+}

--- a/src/main/java/jp/ac/titech/c/se/stein/core/Configurable.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/Configurable.java
@@ -1,0 +1,7 @@
+package jp.ac.titech.c.se.stein.core;
+
+public interface Configurable {
+    void addOptions(final Config conf);
+
+    void configure(final Config conf);
+}

--- a/src/main/java/jp/ac/titech/c/se/stein/core/EntrySet.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/EntrySet.java
@@ -1,4 +1,4 @@
-package finergit.rewrite;
+package jp.ac.titech.c.se.stein.core;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/jp/ac/titech/c/se/stein/core/RefEntry.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/RefEntry.java
@@ -1,4 +1,4 @@
-package finergit.rewrite;
+package jp.ac.titech.c.se.stein.core;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;

--- a/src/main/java/jp/ac/titech/c/se/stein/core/RefEntry.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/RefEntry.java
@@ -15,7 +15,7 @@ public class RefEntry {
 
     public static final RefEntry EMPTY = new RefEntry(null, null, null);
 
-    public RefEntry(final String name, final ObjectId id, final String target) {
+    private RefEntry(final String name, final ObjectId id, final String target) {
         this.name = name;
         this.id = id;
         this.target = target;

--- a/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryAccess.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryAccess.java
@@ -1,4 +1,4 @@
-package finergit.rewrite;
+package jp.ac.titech.c.se.stein.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,8 +21,8 @@ import org.eclipse.jgit.treewalk.TreeWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import finergit.rewrite.EntrySet.Entry;
-import finergit.rewrite.Try.ThrowableFunction;
+import jp.ac.titech.c.se.stein.core.EntrySet.Entry;
+import jp.ac.titech.c.se.stein.core.Try.ThrowableFunction;
 
 public class RepositoryAccess {
     private static final Logger log = LoggerFactory.getLogger(RepositoryAccess.class);

--- a/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryAccess.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryAccess.java
@@ -7,13 +7,16 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.CommitBuilder;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.RefRename;
 import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.TagBuilder;
 import org.eclipse.jgit.lib.TreeFormatter;
 import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -24,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import jp.ac.titech.c.se.stein.core.EntrySet.Entry;
 import jp.ac.titech.c.se.stein.core.Try.ThrowableFunction;
 
-public class RepositoryAccess {
+public class RepositoryAccess implements Configurable {
     private static final Logger log = LoggerFactory.getLogger(RepositoryAccess.class);
 
     protected Repository repo;
@@ -33,7 +36,26 @@ public class RepositoryAccess {
 
     protected boolean overwrite = true;
 
+    protected boolean dryRunning = false;
+
     public RepositoryAccess() {
+    }
+
+    public void setDryRunning(final boolean dryRunning) {
+        this.dryRunning = dryRunning;
+        log.debug("Dry running mode: {}", dryRunning);
+    }
+
+    @Override
+    public void addOptions(final Config conf) {
+        conf.addOption("n", "dry-run", false, "don't actually write anything");
+    }
+
+    @Override
+    public void configure(final Config conf) {
+        if (conf.hasOption("dry-run")) {
+            setDryRunning(true);
+        }
     }
 
     public void initialize(final Repository repo) {
@@ -43,7 +65,7 @@ public class RepositoryAccess {
     public void initialize(final Repository readRepo, final Repository writeRepo) {
         this.repo = readRepo;
         this.writeRepo = writeRepo;
-        this.overwrite = repo == writeRepo;
+        this.overwrite = readRepo == writeRepo;
     }
 
     /**
@@ -79,7 +101,7 @@ public class RepositoryAccess {
         for (final Entry e : sortEntries(entries)) {
             f.append(e.name, e.mode, e.id);
         }
-        return tryInsert((ins) -> ins.insert(f));
+        return tryInsert((ins) -> dryRunning ? ins.idFor(f) : ins.insert(f));
     }
 
     /**
@@ -108,23 +130,50 @@ public class RepositoryAccess {
      * Writes data to a blob object.
      */
     public ObjectId writeBlob(final byte[] data) {
-        return tryInsert((ins) -> ins.insert(Constants.OBJ_BLOB, data));
+        return tryInsert((ins) -> dryRunning ? ins.idFor(Constants.OBJ_BLOB, data) : ins.insert(Constants.OBJ_BLOB, data));
+    }
+
+    /**
+     * Writes a commit object.
+     */
+    protected ObjectId writeCommit(final ObjectId[] parentIds, final ObjectId treeId, final PersonIdent author, final PersonIdent committer, final String message) {
+        final CommitBuilder builder = new CommitBuilder();
+        builder.setParentIds(parentIds);
+        builder.setTreeId(treeId);
+        builder.setAuthor(author);
+        builder.setCommitter(committer);
+        builder.setMessage(message);
+        return tryInsert((ins) -> dryRunning ? ins.idFor(Constants.OBJ_COMMIT, builder.build()) : ins.insert(builder));
+    }
+
+    /**
+     * Writes a tag object.
+     */
+    protected ObjectId writeTag(final ObjectId objectId, final String tag, final PersonIdent tagger, final String message) {
+        final TagBuilder builder = new TagBuilder();
+        builder.setObjectId(objectId, Constants.OBJ_COMMIT);
+        builder.setTag(tag);
+        builder.setTagger(tagger);
+        builder.setMessage(message);
+        return tryInsert((ins) -> dryRunning ? ins.idFor(Constants.OBJ_TAG, builder.build()) : ins.insert(builder));
     }
 
     /**
      * Applies ref update.
      */
     protected void applyRefUpdate(final RefEntry entry) {
-        Try.io(() -> {
-            final RefUpdate cmd = writeRepo.getRefDatabase().newUpdate(entry.name, false);
-            cmd.setForceUpdate(true);
-            if (entry.isSymbolic()) {
-                cmd.link(entry.target);
-            } else {
-                cmd.setNewObjectId(entry.id);
-                cmd.update();
-            }
-        });
+        if (!dryRunning) {
+            Try.io(() -> {
+                final RefUpdate cmd = writeRepo.getRefDatabase().newUpdate(entry.name, false);
+                cmd.setForceUpdate(true);
+                if (entry.isSymbolic()) {
+                    cmd.link(entry.target);
+                } else {
+                    cmd.setNewObjectId(entry.id);
+                    cmd.update();
+                }
+            });
+        }
     }
 
     /**
@@ -157,21 +206,25 @@ public class RepositoryAccess {
      * Applies ref delete.
      */
     protected void applyRefDelete(final RefEntry entry) {
-        Try.io(() -> {
-            final RefUpdate cmd = writeRepo.getRefDatabase().newUpdate(entry.name, false);
-            cmd.setForceUpdate(true);
-            cmd.delete();
-        });
+        if (!dryRunning) {
+            Try.io(() -> {
+                final RefUpdate cmd = writeRepo.getRefDatabase().newUpdate(entry.name, false);
+                cmd.setForceUpdate(true);
+                cmd.delete();
+            });
+        }
     }
 
     /**
      * Applies ref rename.
      */
     protected void applyRefRename(final String name, final String newName) {
-        Try.io(() -> {
-            final RefRename cmd = writeRepo.getRefDatabase().newRename(name, newName);
-            cmd.rename();
-        });
+        if (!dryRunning) {
+            Try.io(() -> {
+                final RefRename cmd = writeRepo.getRefDatabase().newRename(name, newName);
+                cmd.rename();
+            });
+        }
     }
 
     /**

--- a/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryRewriter.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryRewriter.java
@@ -1,4 +1,4 @@
-package finergit.rewrite;
+package jp.ac.titech.c.se.stein.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,8 +22,8 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import finergit.rewrite.EntrySet.Entry;
-import finergit.rewrite.Try.ThrowableFunction;
+import jp.ac.titech.c.se.stein.core.EntrySet.Entry;
+import jp.ac.titech.c.se.stein.core.Try.ThrowableFunction;
 
 public class RepositoryRewriter extends RepositoryAccess {
     private static final Logger log = LoggerFactory.getLogger(RepositoryRewriter.class);

--- a/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryRewriter.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/RepositoryRewriter.java
@@ -7,14 +7,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.jgit.lib.CommitBuilder;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectInserter;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.TagBuilder;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevTag;
@@ -130,13 +128,12 @@ public class RepositoryRewriter extends RepositoryAccess {
      * @return the object ID of the rewritten commit
      */
     protected ObjectId rewriteCommit(final RevCommit commit) {
-        final CommitBuilder builder = new CommitBuilder();
-        builder.setParentIds(rewriteParents(commit.getParents()));
-        builder.setTreeId(rewriteRootTree(commit.getTree().getId()));
-        builder.setAuthor(rewriteAuthor(commit.getAuthorIdent(), commit));
-        builder.setCommitter(rewriteCommitter(commit.getCommitterIdent(), commit));
-        builder.setMessage(rewriteCommitMessage(commit.getFullMessage(), commit));
-        final ObjectId newId = tryInsert((i) -> i.insert(builder));
+        final ObjectId[] parentIds = rewriteParents(commit.getParents());
+        final ObjectId treeId = rewriteRootTree(commit.getTree().getId());
+        final PersonIdent author = rewriteAuthor(commit.getAuthorIdent(), commit);
+        final PersonIdent committer = rewriteCommitter(commit.getCommitterIdent(), commit);
+        final String message = rewriteCommitMessage(commit.getFullMessage(), commit);
+        final ObjectId newId = writeCommit(parentIds, treeId, author, committer, message);
 
         final ObjectId oldId = commit.getId();
         commitMapping.put(oldId, newId);
@@ -209,7 +206,11 @@ public class RepositoryRewriter extends RepositoryAccess {
      * Rewrites a blob object.
      */
     protected ObjectId rewriteBlob(final ObjectId blobId, final Entry entry) {
-        return blobId;
+        if (overwrite) {
+            return blobId;
+        } else {
+            return writeBlob(readBlob(blobId));
+        }
     }
 
     /**
@@ -293,10 +294,29 @@ public class RepositoryRewriter extends RepositoryAccess {
     protected void updateRef(final Ref ref) {
         final RefEntry oldEntry = new RefEntry(ref);
         final RefEntry newEntry = getRefEntry(oldEntry, ref);
-        if (overwrite && !oldEntry.equals(newEntry)) {
-            applyRefDelete(oldEntry);
+        if (newEntry == RefEntry.EMPTY) {
+            // delete
+            if (overwrite) {
+                log.debug("Delete ref: {}", oldEntry);
+                applyRefDelete(oldEntry);
+            }
+            return;
         }
-        if (newEntry != RefEntry.EMPTY) {
+
+        if (!oldEntry.name.equals(newEntry.name)) {
+            // rename
+            if (overwrite) {
+                log.debug("Rename ref: {} -> {}", oldEntry.name, newEntry.name);
+                applyRefRename(oldEntry.name, newEntry.name);
+            }
+        }
+
+        final boolean linkEquals = oldEntry.target == null ? newEntry.target == null : oldEntry.target.equals(newEntry.target);
+        final boolean idEquals = oldEntry.id == null ? newEntry.id == null : oldEntry.id.name().equals(newEntry.id.name());
+
+        if (!overwrite || !linkEquals || !idEquals) {
+            // update
+            log.debug("Update ref: [{}] -> [{}]", oldEntry, newEntry);
             applyRefUpdate(newEntry);
         }
     }
@@ -345,13 +365,10 @@ public class RepositoryRewriter extends RepositoryAccess {
         }
         log.debug("Rewrite tag target: {} -> {}", tag.getObject().name(), newObjectId.name());
 
-        final TagBuilder builder = new TagBuilder();
-        builder.setObjectId(newObjectId, Constants.OBJ_COMMIT);
-        builder.setTag(rewriteTagName(tag.getTagName(), ref));
-        builder.setTagger(rewriteTagger(tag.getTaggerIdent(), tag, ref));
-        builder.setMessage(rewriteTagMessage(tag.getFullMessage(), tag, ref));
-
-        final ObjectId newId = tryInsert((i) -> i.insert(builder));
+        final String tagName = tag.getTagName();
+        final PersonIdent tagger = rewriteTagger(tag.getTaggerIdent(), tag, ref);
+        final String message = rewriteTagMessage(tag.getFullMessage(), tag, ref);
+        final ObjectId newId = writeTag(newObjectId, tagName, tagger, message);
         log.debug("Rewrite tag: {} -> {}", tagId.name(), newId.name());
         return newId;
     }

--- a/src/main/java/jp/ac/titech/c/se/stein/core/Try.java
+++ b/src/main/java/jp/ac/titech/c/se/stein/core/Try.java
@@ -1,4 +1,4 @@
-package finergit.rewrite;
+package jp.ac.titech.c.se.stein.core;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;


### PR DESCRIPTION
Changes:
- Follow the latest stein library. To minimize the migration effort, now the name of its package is the same as the original.
- Use copy-and-rewrite. Now the conversion first copies the `--src` repository to `--des`, and rewrite the copied repository.
- Now all the local branches and tags are rewritten.
- After rewriting the repository database, the working copy now follows HEAD.