### PR TITLE
enumにおいてメソッドの抽出処理が未実装だったので実装した

### DIFF
--- a/src/main/java/finergit/ast/JavaFileVisitor.java
+++ b/src/main/java/finergit/ast/JavaFileVisitor.java
@@ -641,7 +641,7 @@ public class JavaFileVisitor extends ASTVisitor {
       this.addToPeekModule(
           new FinerJavaClassToken("ClassToken[" + finerJavaClass.name + "]", finerJavaClass));
     }
-    
+
     return false;
   }
 
@@ -1081,8 +1081,12 @@ public class JavaFileVisitor extends ASTVisitor {
     final List<String> types = new ArrayList<>();
     for (final Object parameter : node.parameters()) {
       final SingleVariableDeclaration svd = (SingleVariableDeclaration) parameter;
-      final String type = svd.getType()
-          .toString()
+      final StringBuilder typeText = new StringBuilder();
+      typeText.append(svd.getType());
+      if (svd.isVarargs()) {
+        typeText.append("...");
+      }
+      final String type = typeText.toString()
           .replace(' ', '-') // avoiding space existences
           .replace('?', '#') // for window's file system
           .replace('<', '[') // for window's file system
@@ -1484,6 +1488,11 @@ public class JavaFileVisitor extends ASTVisitor {
     // 型の処理
     node.getType()
         .accept(this);
+
+    // 可変長引数なら"..."を追加
+    if (node.isVarargs()) {
+      this.addToPeekModule(new VariableArity());
+    }
 
     {// 変数名の処理
       this.contexts.push(VARIABLENAME.class);

--- a/src/main/java/finergit/ast/JavaFileVisitor.java
+++ b/src/main/java/finergit/ast/JavaFileVisitor.java
@@ -633,6 +633,15 @@ public class JavaFileVisitor extends ASTVisitor {
 
     this.addToPeekModule(new RIGHTCLASSBRACKET());
 
+    this.classNestLevel--;
+
+    // インナークラスでない場合は，モジュールスタックからクラスモジュールをポップし，外側のモジュールにクラスを表すトークンを追加する
+    if (0 == this.classNestLevel) {
+      final FinerJavaClass finerJavaClass = (FinerJavaClass) this.moduleStack.pop();
+      this.addToPeekModule(
+          new FinerJavaClassToken("ClassToken[" + finerJavaClass.name + "]", finerJavaClass));
+    }
+    
     return false;
   }
 

--- a/src/main/java/finergit/ast/JavaFileVisitor.java
+++ b/src/main/java/finergit/ast/JavaFileVisitor.java
@@ -290,7 +290,7 @@ public class JavaFileVisitor extends ASTVisitor {
       this.addToPeekModule(left ? new LEFTCATCHCLAUSEBRACKET() : new RIGHTCATCHCLAUSEBRACKET());
     } else if (WhileStatement.class == parent.getClass()) {
       this.addToPeekModule(left ? new LEFTWHILEBRACKET() : new RIGHTWHILEBRACKET());
-    }else if(LabeledStatement.class == parent.getClass()){
+    } else if (LabeledStatement.class == parent.getClass()) {
       // ラベル文のときには，ここにくるのはラベル文の文の部分がシンプルブロックのはず
       this.addToPeekModule(left ? new LEFTSIMPLEBLOCKBRACKET() : new RIGHTSIMPLEBLOCKBRACKET());
     } else {
@@ -590,6 +590,18 @@ public class JavaFileVisitor extends ASTVisitor {
   @Override
   public boolean visit(final EnumDeclaration node) {
 
+    // インナークラスでない場合は，新しいクラスモジュールを作り，モジュールスタックにpush
+    if (0 == this.classNestLevel) {
+      final FinerJavaModule outerModule = this.moduleStack.peek();
+      final String className = node.getName()
+          .getIdentifier();
+      final FinerJavaClass classModule = new FinerJavaClass(className, outerModule, this.config);
+      this.moduleStack.push(classModule);
+      this.moduleList.add(classModule);
+    }
+
+    this.classNestLevel++;
+
     // Javadoc コメントの処理
     final Javadoc javadoc = node.getJavadoc();
     if (null != javadoc) {
@@ -603,15 +615,23 @@ public class JavaFileVisitor extends ASTVisitor {
       this.addToPeekModule(modifierToken);
     }
 
+    // "class"の処理
+    this.addToPeekModule(new ENUM());
+
     this.contexts.push(CLASSNAME.class);
     node.getName()
         .accept(this);
     final Class<?> context = this.contexts.pop();
     assert CLASSNAME.class == context : "error happend at JavaFileVisitor#visit(EnumDeclaration)";
 
-    for (final Object enumConstant : node.enumConstants()) {
-      ((EnumConstantDeclaration) enumConstant).accept(this);
+    this.addToPeekModule(new LEFTCLASSBRACKET());
+
+    for (final Object o : node.bodyDeclarations()) {
+      final BodyDeclaration body = (BodyDeclaration) o;
+      body.accept(this);
     }
+
+    this.addToPeekModule(new RIGHTCLASSBRACKET());
 
     return false;
   }

--- a/src/main/java/finergit/ast/token/VariableArity.java
+++ b/src/main/java/finergit/ast/token/VariableArity.java
@@ -1,0 +1,9 @@
+package finergit.ast.token;
+
+
+public class VariableArity extends JavaToken {
+
+  public VariableArity() {
+    super("...");
+  }
+}

--- a/src/test/java/finergit/ast/FinerJavaFileBuilderTest.java
+++ b/src/test/java/finergit/ast/FinerJavaFileBuilderTest.java
@@ -343,4 +343,18 @@ public class FinerJavaFileBuilderTest {
       }
     }
   }
+
+  @Test
+  public void getFinerJavaModulesSuccessTest10() throws Exception {
+    final Path targetPath = Paths.get("src/test/resources/finergit/ast/Enum.java");
+    final String text = String.join(System.lineSeparator(), Files.readAllLines(targetPath));
+    final FinerJavaFileBuilder builder = new FinerJavaFileBuilder(new FinerGitConfig());
+    final List<FinerJavaModule> modules = builder.getFinerJavaModules(targetPath.toString(), text);
+
+    final Set<String> moduleNames = modules.stream()
+        .map(m -> m.getFileName())
+        .collect(Collectors.toSet());
+    assertThat(moduleNames).containsExactlyInAnyOrder("Enum.cjava",
+        "Enum$public_String_toString().mjava");
+  }
 }

--- a/src/test/java/finergit/ast/FinerJavaFileBuilderTest.java
+++ b/src/test/java/finergit/ast/FinerJavaFileBuilderTest.java
@@ -357,4 +357,20 @@ public class FinerJavaFileBuilderTest {
     assertThat(moduleNames).containsExactlyInAnyOrder("Enum.cjava",
         "Enum$public_String_toString().mjava");
   }
+
+  @Test
+  public void getFinerJavaModulesSuccessTest11() throws Exception {
+    final Path targetPath =
+        Paths.get("src/test/resources/finergit/ast/VariableLengthParameter.java");
+    final String text = String.join(System.lineSeparator(), Files.readAllLines(targetPath));
+    final FinerJavaFileBuilder builder = new FinerJavaFileBuilder(new FinerGitConfig());
+    final List<FinerJavaModule> modules = builder.getFinerJavaModules(targetPath.toString(), text);
+
+    final List<String> moduleNames = modules.stream()
+        .map(m -> m.getFileName())
+        .collect(Collectors.toList());
+    assertThat(moduleNames).containsExactlyInAnyOrder("VariableLengthParameter.cjava",
+        "VariableLengthParameter$public_String_method01(String).mjava",
+        "VariableLengthParameter$public_String_method01(String...).mjava");
+  }
 }

--- a/src/test/resources/finergit/ast/Enum.java
+++ b/src/test/resources/finergit/ast/Enum.java
@@ -1,0 +1,25 @@
+package finergit.ast;
+
+
+public enum Enum {
+
+  A {
+
+    @Override
+    public String toString() {
+      return "A";
+    }
+  },
+
+  B {
+
+    @Override
+    public String toString() {
+      return "B";
+    }
+  };
+
+  public String toString() {
+    return "";
+  }
+}

--- a/src/test/resources/finergit/ast/VariableLengthParameter.java
+++ b/src/test/resources/finergit/ast/VariableLengthParameter.java
@@ -1,0 +1,14 @@
+package finergit.ast;
+
+
+public class VariableLengthParameter {
+
+  public String method01(String a) {
+    return "A";
+  }
+
+  public String method01(String... b) {
+    return "B";
+  }
+
+}


### PR DESCRIPTION
`Entry occurred twice`はこれでかなり軽減するはず．
ただ，まだ完全に解決したわけではない．

refer #119 