### PR TITLE
細粒度ファイル名に元のファイル名を追加する処理を追加

### DIFF
--- a/src/main/java/finergit/ast/FinerJavaClass.java
+++ b/src/main/java/finergit/ast/FinerJavaClass.java
@@ -21,4 +21,34 @@ public class FinerJavaClass extends FinerJavaModule {
   public String getExtension() {
     return CLASS_FILE_EXTENSION;
   }
+
+  /**
+   * ベースネーム（拡張子がないファイル名）を返す．
+   * 
+   * @return
+   */
+  public String getBaseName() {
+
+    final StringBuilder builder = new StringBuilder();
+    
+    // 外側のモジュールがファイル名の場合は，
+    // ファイル名とこのクラス名が違う場合のみ，
+    // ファイル名を含める
+    if (FinerJavaFile.class == this.outerModule.getClass()) {
+      if (!this.name.equals(this.outerModule.name)) {
+        builder.append("[")
+            .append(this.outerModule.name)
+            .append("]");
+      }
+    }
+
+    // 内部クラスの場合は外側のクラス名を含める
+    else if (FinerJavaClass.class == this.outerModule.getClass()) {
+      builder.append(this.outerModule.getBaseName())
+          .append("$");
+    }
+
+    builder.append(this.name);
+    return builder.toString();
+  }
 }

--- a/src/main/java/finergit/ast/FinerJavaFile.java
+++ b/src/main/java/finergit/ast/FinerJavaFile.java
@@ -33,4 +33,13 @@ public class FinerJavaFile extends FinerJavaModule {
   public String getExtension() {
     return ".fjava";
   }
+
+  /**
+   * ベースネーム（拡張子がないファイル名）を返す．
+   * 
+   * @return
+   */
+  public String getBaseName() {
+    return this.name;
+  }
 }

--- a/src/main/java/finergit/ast/FinerJavaMethod.java
+++ b/src/main/java/finergit/ast/FinerJavaMethod.java
@@ -21,4 +21,13 @@ public class FinerJavaMethod extends FinerJavaModule {
   public String getExtension() {
     return METHOD_FILE_EXTENSION;
   }
+
+  /**
+   * ベースネーム（拡張子がないファイル名）を返す．
+   * 
+   * @return
+   */
+  public String getBaseName() {
+    return this.outerModule.getBaseName() + "$" + this.name;
+  }
 }

--- a/src/main/java/finergit/ast/FinerJavaModule.java
+++ b/src/main/java/finergit/ast/FinerJavaModule.java
@@ -89,25 +89,17 @@ public abstract class FinerJavaModule {
     return shrinkedName.toString();
   }
 
-  /**
-   * ベースネーム（拡張子がないファイル名）を返す．
-   * 
-   * @return
-   */
-  public final String getBaseName() {
-    final StringBuilder builder = new StringBuilder();
-    if ((null != this.outerModule) && (FinerJavaFile.class != this.outerModule.getClass())) {
-      builder.append(this.outerModule.getBaseName());
-      builder.append("$");
-    }
-    builder.append(this.name);
-    return builder.toString();
-  }
-
   public final Path getPath() {
     return this.getDirectory()
         .resolve(this.getFileName());
   }
 
   public abstract String getExtension();
+
+  /**
+   * ベースネーム（拡張子がないファイル名）を返す．
+   * 
+   * @return
+   */
+  abstract public String getBaseName();
 }

--- a/src/test/java/finergit/ast/FinerJavaFileBuilderTest.java
+++ b/src/test/java/finergit/ast/FinerJavaFileBuilderTest.java
@@ -405,4 +405,19 @@ public class FinerJavaFileBuilderTest {
         "ArrayDefinition$public_void_set(int[][]).mjava",
         "ArrayDefinition$public_void_set(int[][][]).mjava");
   }
+
+  @Test
+  public void getFinerJavaModulesSuccessTest14() throws Exception {
+    final Path targetPath = Paths.get("src/test/resources/finergit/ast/ClassName.java");
+    final String text = String.join(System.lineSeparator(), Files.readAllLines(targetPath));
+    final FinerJavaFileBuilder builder = new FinerJavaFileBuilder(new FinerGitConfig());
+    final List<FinerJavaModule> modules = builder.getFinerJavaModules(targetPath.toString(), text);
+
+    final List<String> moduleNames = modules.stream()
+        .map(m -> m.getFileName())
+        .collect(Collectors.toList());
+    assertThat(moduleNames).containsExactlyInAnyOrder("ClassName.cjava",
+        "ClassName$public_void_set(String).mjava", "[ClassName]A.cjava",
+        "[ClassName]A$public_void_set(String).mjava");
+  }
 }

--- a/src/test/resources/finergit/ast/ClassName.java
+++ b/src/test/resources/finergit/ast/ClassName.java
@@ -1,0 +1,15 @@
+package finergit.ast;
+
+
+public class ClassName {
+
+  public void set(String a) {}
+}
+
+
+class A {
+
+  public void set(String b) {
+
+  }
+}


### PR DESCRIPTION
異なる2つのファイルが同じ名前のクラスを含む場合あるため，
クラス名とそのファイル名が異なる場合は，
細粒度ファイルにファイル名も追加するようにした．