### PR TITLE
ファイルコピーにおいてシンボリックリンクの中身を見ないように修正

### DIFF
--- a/src/main/java/finergit/FinerRepoBuilder.java
+++ b/src/main/java/finergit/FinerRepoBuilder.java
@@ -3,6 +3,7 @@ package finergit;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -69,7 +70,7 @@ public class FinerRepoBuilder {
       @Override
       public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs)
           throws IOException {
-        Files.copy(file, target.resolve(source.relativize(file)));
+        Files.copy(file, target.resolve(source.relativize(file)), LinkOption.NOFOLLOW_LINKS);
         return FileVisitResult.CONTINUE;
       }
     });


### PR DESCRIPTION
resolve #132 